### PR TITLE
Add Protobuf parser and renderer to registry

### DIFF
--- a/src/main/java/smartthings/ratpack/protobuf/ProtobufModule.java
+++ b/src/main/java/smartthings/ratpack/protobuf/ProtobufModule.java
@@ -1,14 +1,18 @@
 package smartthings.ratpack.protobuf;
 
 import ratpack.guice.ConfigurableModule;
+import smartthings.ratpack.protobuf.parsers.ProtobufParser;
+import smartthings.ratpack.protobuf.renderers.ProtobufRenderer;
 
 /**
- * Guice bindings for Smart Things Protobuf Parsing/Rendering.
+ * Guice bindings for SmartThings Protobuf Parsing/Rendering.
  */
 public class ProtobufModule extends ConfigurableModule<ProtobufModule.Config>{
 
     @Override
     protected void configure() {
+        bind(ProtobufParser.class);
+        bind(ProtobufRenderer.class);
     }
 
     /**

--- a/src/test/groovy/smartthings/ratpack/protobuf/ProtobufModuleSpec.groovy
+++ b/src/test/groovy/smartthings/ratpack/protobuf/ProtobufModuleSpec.groovy
@@ -1,0 +1,43 @@
+package smartthings.ratpack.protobuf
+
+import ratpack.groovy.test.embed.GroovyEmbeddedApp
+import ratpack.http.client.RequestSpec
+import smartthings.ratpack.protobuf.WidgetProtos.Widget
+import spock.lang.Specification
+
+class ProtobufModuleSpec extends Specification {
+    def "Renders and parsers are registered properly"() {
+        given:
+        String id = UUID.randomUUID().toString()
+        Widget widget = Widget.newBuilder()
+                .setId(id)
+                .setName("ST Protobuf")
+                .build()
+
+        expect:
+        GroovyEmbeddedApp.ratpack {
+            bindings {
+                moduleConfig(ProtobufModule, new ProtobufModule.Config(cache: new CacheConfig()))
+            }
+            handlers {
+                post {
+                    parse(Widget).then {
+                        render it
+                    }
+                }
+            }
+        }.test {
+            requestSpec { RequestSpec requestSpec ->
+                requestSpec.headers.add("Accept", ContentType.PROTOBUF.value)
+                requestSpec.body.type(ContentType.PROTOBUF.value)
+                requestSpec.body.bytes(widget.toByteArray())
+            }
+            def response = post()
+
+            assert response.status.code == 200
+            Widget result = Widget.parseFrom(response.body.getBytes())
+            assert result.name == "ST Protobuf"
+            assert result.id == id
+        }
+    }
+}


### PR DESCRIPTION
@jeff-blaisdell 

I was consuming this in a microservice and noticed that it wasn't finding the parser despite registering the module.